### PR TITLE
Clustered Gaffer

### DIFF
--- a/Dockerfile.accumulo
+++ b/Dockerfile.accumulo
@@ -14,7 +14,7 @@
 # limitations under the License.
 ##########################################################
 
-FROM cybermaggedon/accumulo:1.8.0
+FROM cybermaggedon/accumulo:1.7.2
 
 COPY product/*.jar /usr/local/accumulo/lib/ext/
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,7 +19,7 @@ FROM fedora:24
 RUN dnf install -y java-1.8.0-openjdk maven
 RUN dnf install -y git
 
-ARG GAFFER_VERSION=0.4.4
+ARG GAFFER_VERSION
 RUN mkdir -p /usr/local/src/gaffer
 WORKDIR /usr/local/src/gaffer
 

--- a/Dockerfile.wildfly
+++ b/Dockerfile.wildfly
@@ -21,6 +21,7 @@ RUN dnf install -y java-1.8.0-openjdk maven
 
 WORKDIR /usr/local
 ADD wildfly-10.1.0.CR1.zip /usr/local/
+RUN unzip wildfly-10.1.0.CR1.zip; rm -f wildfly-10.1.0.CR1.zip
 RUN ln -s wildfly-10.1.0.CR1 wildfly
 
 WORKDIR /usr/local/wildfly
@@ -34,5 +35,4 @@ CMD cd /usr/local/wildfly; \
       -Dgaffer.storeProperties=/usr/local/wildfly/store.properties
 
 EXPOSE 8080
-
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,6 @@ VERSION=0.4.4c
 ACCUMULO_REPOSITORY=cybermaggedon/accumulo-gaffer
 WILDFLY_REPOSITORY=cybermaggedon/wildfly-gaffer
 
-JACKSON=com/fasterxml/jackson
-
 WAR_FILES=\
 	gaffer/example-rest/${GAFFER_VERSION}/example-rest-${GAFFER_VERSION}.war \
         gaffer/ui/${GAFFER_VERSION}/ui-${GAFFER_VERSION}.war

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@
 
 GAFFER_VERSION=0.4.4
 VERSION=0.4.4c
-ACCUMULO_REPOSITORY=cybermaggedon/accumulo-gaffer
-WILDFLY_REPOSITORY=cybermaggedon/wildfly-gaffer
+ACCUMULO_REPOSITORY=gchq/accumulo-gaffer
+WILDFLY_REPOSITORY=gchq/wildfly-gaffer
 
 WAR_FILES=\
 	gaffer/example-rest/${GAFFER_VERSION}/example-rest-${GAFFER_VERSION}.war \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 ##########################################################
 
 GAFFER_VERSION=0.4.4
-VERSION=0.4.4c
+VERSION=0.4.4d
 ACCUMULO_REPOSITORY=gchq/accumulo-gaffer
 WILDFLY_REPOSITORY=gchq/wildfly-gaffer
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ components:
 - Hadoop, which is used by Accumulo.
 
 I have these components available as the four containers:
-- cybermaggedon/wildfly-gaffer
-- cybermaggedon/accumulo-gaffer
+- gchq/wildfly-gaffer
+- gchq/accumulo-gaffer
 - cybermaggedon/zookeeper
 - cybermaggedon/hadoop
 
@@ -56,12 +56,12 @@ To run:
 
   # Run Accumulo
   docker run --rm --name accumulo --link zookeeper:zookeeper \
-        --link hadoop:hadoop cybermaggedon/accumulo-gaffer:0.4.4c
+        --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4c
 
   # Run Wildfly, exposing port 8080.
   docker run --rm --name wildfly --link zookeeper:zookeeper \
     --link hadoop:hadoop --link accumulo:accumulo \
-    -p 8080:8080 cybermaggedon/wildfly-gaffer:0.4.4c
+    -p 8080:8080 gchq/wildfly-gaffer:0.4.4c
 
 ```
 
@@ -83,12 +83,12 @@ Wildfly needs no persistent state.
   # Run Accumulo
   docker run --rm --name accumulo -v /data/accumulo:/accumulo \
         --link zookeeper:zookeeper \
-        --link hadoop:hadoop cybermaggedon/accumulo-gaffer:0.4.4c
+        --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4c
 
   # Run Wildfly, exposing port 8080.
   docker run --rm --name wildfly --link zookeeper:zookeeper \
     --link hadoop:hadoop --link accumulo:accumulo \
-    -p 8080:8080 cybermaggedon/wildfly-gaffer:0.4.4c
+    -p 8080:8080 gchq/wildfly-gaffer:0.4.4c
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ To run:
 
   # Run Accumulo
   docker run --rm --name accumulo --link zookeeper:zookeeper \
-        --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4c
+        --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4d
 
   # Run Wildfly, exposing port 8080.
   docker run --rm --name wildfly --link zookeeper:zookeeper \
     --link hadoop:hadoop --link accumulo:accumulo \
-    -p 8080:8080 gchq/wildfly-gaffer:0.4.4c
+    -p 8080:8080 gchq/wildfly-gaffer:0.4.4d
 
 ```
 
@@ -83,12 +83,12 @@ Wildfly needs no persistent state.
   # Run Accumulo
   docker run --rm --name accumulo -v /data/accumulo:/accumulo \
         --link zookeeper:zookeeper \
-        --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4c
+        --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4d
 
   # Run Wildfly, exposing port 8080.
   docker run --rm --name wildfly --link zookeeper:zookeeper \
     --link hadoop:hadoop --link accumulo:accumulo \
-    -p 8080:8080 gchq/wildfly-gaffer:0.4.4c
+    -p 8080:8080 gchq/wildfly-gaffer:0.4.4d
 
 ```
 

--- a/kubernetes/README.kubernetes.md
+++ b/kubernetes/README.kubernetes.md
@@ -1,3 +1,18 @@
+Copyright 2016 Crown Copyright, cybermaggedon
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----
 
 Here's some template configuration files to run Gaffer on Kubernetes
 in the Google cloud.  This template uses three ext4 disks in the cloud, the

--- a/kubernetes/gaffer-deployment.yaml
+++ b/kubernetes/gaffer-deployment.yaml
@@ -1,3 +1,16 @@
+# Copyright 2016 Crown Copyright, cybermaggedon
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -35,7 +48,7 @@ spec:
           - mountPath: /data
             name: zookeeper
       - name: accumulo
-        image: cybermaggedon/accumulo-gaffer:0.4.4c
+        image: gchq/accumulo-gaffer:0.4.4d
         resources:
           requests:
             memory: "2048M"
@@ -47,7 +60,7 @@ spec:
           - mountPath: /accumulo
             name: accumulo
       - name: gaffer
-        image: cybermaggedon/wildfly-gaffer:0.4.4c
+        image: gchq/wildfly-gaffer:0.4.4d
         resources:
           requests:
             memory: "700M"

--- a/kubernetes/gaffer-services.yaml
+++ b/kubernetes/gaffer-services.yaml
@@ -1,3 +1,16 @@
+# Copyright 2016 Crown Copyright, cybermaggedon
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 apiVersion: v1
 kind: Service
 metadata:

--- a/run_gaffer
+++ b/run_gaffer
@@ -39,10 +39,10 @@ docker run -d --name zookeeper -v ${data_dir}/zookeeper:/data \
 # Run Accumulo
 docker run -d --name accumulo -v ${data_dir}/accumulo:/accumulo \
        --link zookeeper:zookeeper \
-       --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4c
+       --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4d
 
 # Run Wildfly, exposing port 8080.
 docker run -d --name wildfly --link zookeeper:zookeeper \
        --link hadoop:hadoop --link accumulo:accumulo \
-       -p 8080:8080 gchq/wildfly-gaffer:0.4.4c
+       -p 8080:8080 gchq/wildfly-gaffer:0.4.4d
 

--- a/run_gaffer
+++ b/run_gaffer
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# Simple script, starts the containers needed to run Gaffer.
+#
+# Copyright 2016 Crown Copyright, cybermaggedon
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Location for persistent data
 data_dir=/data
 
@@ -22,10 +39,10 @@ docker run -d --name zookeeper -v ${data_dir}/zookeeper:/data \
 # Run Accumulo
 docker run -d --name accumulo -v ${data_dir}/accumulo:/accumulo \
        --link zookeeper:zookeeper \
-       --link hadoop:hadoop cybermaggedon/accumulo-gaffer:0.4.4c
+       --link hadoop:hadoop gchq/accumulo-gaffer:0.4.4c
 
 # Run Wildfly, exposing port 8080.
 docker run -d --name wildfly --link zookeeper:zookeeper \
        --link hadoop:hadoop --link accumulo:accumulo \
-       -p 8080:8080 cybermaggedon/wildfly-gaffer:0.4.4c
+       -p 8080:8080 gchq/wildfly-gaffer:0.4.4c
 

--- a/run_gaffer
+++ b/run_gaffer
@@ -34,7 +34,7 @@ docker run -d --name hadoop -v ${data_dir}/hadoop:/data \
 
 # Run Zookeeper
 docker run -d --name zookeeper -v ${data_dir}/zookeeper:/data \
-       cybermaggedon/zookeeper:3.4.9
+       cybermaggedon/zookeeper:3.4.9b
 
 # Run Accumulo
 docker run -d --name accumulo -v ${data_dir}/accumulo:/accumulo \


### PR DESCRIPTION
This change incorporates changes to use Hadoop, Zookeeper and Accumulo in cluster mode. I have also included a sample configuration to run this in Google Cloud's container engine.

My gchq-upstream branch has repo naming schemes that should work for you, and this is back-ported to Accumulo 1.7.2 as you requested.


