### PR TITLE
JupyterLab Spark resource bugfixes

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -31,7 +31,7 @@ jobs:
       run: ./cd/deploy_to_kind.sh
   
     - name: Run gaffer-road-traffic Tests
-      run: helm test gaffer || (kubectl get po && kubectl describe po && kubectl logs -l app.kubernetes.io/component=test && df -h && false)
+      run: helm test gaffer || (kubectl get po && kubectl describe po && kubectl logs -l app.kubernetes.io/component=test --tail=-1 && df -h && false)
 
     - name: Run gaffer-jhub Tests
-      run: helm test jhub || (kubectl get po && kubectl describe po && kubectl logs -l app.kubernetes.io/component=test && df -h && false)
+      run: helm test jhub || (kubectl get po && kubectl describe po && kubectl logs -l app.kubernetes.io/component=test --tail=-1 && df -h && false)

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
 
     - name: Maximize build space
-      uses: easimon/maximize-build-space@v2
+      uses: easimon/maximize-build-space@v4
       with:
         remove-dotnet: 'true'
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -11,6 +11,7 @@ jobs:
       uses: easimon/maximize-build-space@v4
       with:
         remove-dotnet: 'true'
+        overprovision-lvm: 'true'
 
     - uses: actions/checkout@v2
 

--- a/docker/gaffer-jhub-options-server/spark-config-provisioner.js
+++ b/docker/gaffer-jhub-options-server/spark-config-provisioner.js
@@ -34,7 +34,7 @@ class SparkConfigProvisioner {
 		}
 	}
 
-	getSparkDefaultProperties(containerImage, namespace, username, servername, serviceAccountName, driverCores, executorCores, hdfsEnabled) {
+	getSparkDefaultProperties(containerImage, namespace, username, servername, serviceAccountName, executorCores, executorMemory, hdfsEnabled) {
 		const props = Object.assign({
 			'spark.ui.port': DEFAULT_UI_PORT
 		}, this.staticProperties)
@@ -56,13 +56,12 @@ class SparkConfigProvisioner {
 		props['spark.kubernetes.executor.label.hub.jupyter.org/username'] = username
 		props['spark.kubernetes.executor.label.hub.jupyter.org/servername'] = servername
 
-		props['spark.driver.cores'] = '1'
-		props['spark.kubernetes.driver.request.cores'] = driverCores || '100m'
-		props['spark.driver.memory'] = '1g'
-
-		props['spark.executor.cores'] = '1'
 		props['spark.kubernetes.executor.request.cores'] = executorCores || '100m'
-		props['spark.executor.memory'] = '1g'
+		props['spark.kubernetes.executor.limit.cores'] = executorCores || '100m'
+
+		props['spark.executor.cores'] = executorCores || "100m"
+		props['spark.executor.memory'] = executorMemory + "m" || '1g'
+
 
 		if (hdfsEnabled) {
 			props['spark.eventLog.enabled'] = 'true'

--- a/docker/gaffer-jhub-options-server/spark-config-provisioner.js
+++ b/docker/gaffer-jhub-options-server/spark-config-provisioner.js
@@ -56,10 +56,9 @@ class SparkConfigProvisioner {
 		props['spark.kubernetes.executor.label.hub.jupyter.org/username'] = username
 		props['spark.kubernetes.executor.label.hub.jupyter.org/servername'] = servername
 
-		props['spark.kubernetes.executor.request.cores'] = executorCores || '100m'
-		props['spark.kubernetes.executor.limit.cores'] = executorCores || '100m'
+		props['spark.kubernetes.executor.request.cores'] = executorCores || '250m'
+		props['spark.kubernetes.executor.limit.cores'] = executorCores || '250m'
 
-		props['spark.executor.cores'] = executorCores || "100m"
 		props['spark.executor.memory'] = executorMemory ? executorMemory + 'm' : '1g'
 
 		if (hdfsEnabled) {

--- a/docker/gaffer-jhub-options-server/spark-config-provisioner.js
+++ b/docker/gaffer-jhub-options-server/spark-config-provisioner.js
@@ -60,8 +60,7 @@ class SparkConfigProvisioner {
 		props['spark.kubernetes.executor.limit.cores'] = executorCores || '100m'
 
 		props['spark.executor.cores'] = executorCores || "100m"
-		props['spark.executor.memory'] = executorMemory + "m" || '1g'
-
+		props['spark.executor.memory'] = executorMemory ? executorMemory + 'm' : '1g'
 
 		if (hdfsEnabled) {
 			props['spark.eventLog.enabled'] = 'true'

--- a/docker/gaffer-jhub-options-server/spark-config-provisioner.js
+++ b/docker/gaffer-jhub-options-server/spark-config-provisioner.js
@@ -166,8 +166,8 @@ class SparkConfigProvisioner {
 		return response
 	}
 
-	async getPodSpecConfig(username, servername, driverServiceName, namespace, sparkContainerImage, serviceAccountName, driverCores, executorCores, hdfsEnabled, ingressHost, ingressPath) {
-		const sparkProperties = this.getSparkDefaultProperties(sparkContainerImage, namespace, username, servername, serviceAccountName, driverCores, executorCores, hdfsEnabled)
+	async getPodSpecConfig(username, servername, driverServiceName, namespace, sparkContainerImage, serviceAccountName, executorCores, executorMemory, hdfsEnabled, ingressHost, ingressPath) {
+		const sparkProperties = this.getSparkDefaultProperties(sparkContainerImage, namespace, username, servername, serviceAccountName, executorCores, executorMemory, hdfsEnabled)
 		const uiPort = sparkProperties['spark.ui.port']
 
 		const [configMap, service, ingress] = await Promise.all([

--- a/docker/gaffer-jhub-options-server/templates/profile_list.pug
+++ b/docker/gaffer-jhub-options-server/templates/profile_list.pug
@@ -35,7 +35,7 @@ div.form-horizontal
 					i.fa.fa-microchip
 					|
 					| CPU
-				input.form-control(type='number' id='resources_cpu' name='resources_cpu' min='0.001' max='128' step='0.001' value='0.250')
+				input.form-control(type='number' id='resources_cpu' name='resources_cpu' min='0.001' max='128' step='0.001' value='1')
 				div.input-group-addon vCPU
 
 		div.col-md-6
@@ -137,7 +137,7 @@ div.form-horizontal
 						i.fa.fa-microchip
 						|
 						| CPU
-					input.form-control(type='number' id='spark_cpu' name='spark_cpu' min='0.1' max='128' step='0.01' value='1')
+					input.form-control(type='number' id='spark_cpu' name='spark_cpu' min='1' max='128' step='1' value='1')
 					div.input-group-addon vCPU
 
 			div.col-md-6
@@ -146,5 +146,5 @@ div.form-horizontal
 						i.fas.fa-memory
 						|
 						| MEM
-					input.form-control(type='number' id='spark_mem' name='spark_mem' min='1' max='262144' step='1' value='512')
+					input.form-control(type='number' id='spark_mem' name='spark_mem' min='1' max='262144' step='1' value='1024')
 					div.input-group-addon MB

--- a/docker/gaffer-jhub-options-server/templates/profile_list.pug
+++ b/docker/gaffer-jhub-options-server/templates/profile_list.pug
@@ -35,7 +35,7 @@ div.form-horizontal
 					i.fa.fa-microchip
 					|
 					| CPU
-				input.form-control(type='number' id='resources_cpu' name='resources_cpu' min='0.001' max='128' step='0.001' value='1')
+				input.form-control(type='number' id='resources_cpu' name='resources_cpu' min='0.001' max='128' step='0.001' value='0.250')
 				div.input-group-addon vCPU
 
 		div.col-md-6
@@ -146,5 +146,5 @@ div.form-horizontal
 						i.fas.fa-memory
 						|
 						| MEM
-					input.form-control(type='number' id='spark_mem' name='spark_mem' min='1' max='262144' step='1' value='1024')
+					input.form-control(type='number' id='spark_mem' name='spark_mem' min='1' max='262144' step='1' value='512')
 					div.input-group-addon MB

--- a/docker/gaffer-pyspark-notebook/Dockerfile
+++ b/docker/gaffer-pyspark-notebook/Dockerfile
@@ -54,7 +54,7 @@ RUN cd /opt/hadoop/share/hadoop/tools/lib && \
 	sed -i -E "s|aws-java-sdk-bundle-[0-9\.]+\.jar|aws-java-sdk-bundle-${AWS_JAVA_SDK_VERSION}\.jar|g" shellprofile.d/hadoop-aws.sh && \
 	sed -i -E "s|aws-java-sdk-bundle-[0-9\.]+\.jar|aws-java-sdk-bundle-${AWS_JAVA_SDK_VERSION}\.jar|g" tools/hadoop-aws.sh
 
-ARG SPARK_VERSION=3.0.0
+ARG SPARK_VERSION=3.0.1
 ARG SPARK_DOWNLOAD_URL=https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-without-hadoop.tgz
 
 RUN cd /opt && \

--- a/kubernetes/gaffer-jhub/files/tests/wait_for_jupyterhub.sh
+++ b/kubernetes/gaffer-jhub/files/tests/wait_for_jupyterhub.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+until [ $(( ATTEMPTS++ )) -gt 30 ]; do
+	result=$(curl -f -s ${HUB_API_URL})
+	rc=$?
+	echo "$(date) - rc: ${rc} result: ${result}"
+
+	[ "${rc}" == "0" ] && exit 0
+
+	sleep 1
+done
+exit 1

--- a/kubernetes/gaffer-jhub/templates/tests/notebook-tests/pod.yaml
+++ b/kubernetes/gaffer-jhub/templates/tests/notebook-tests/pod.yaml
@@ -12,10 +12,16 @@ spec:
   initContainers:
   - name: wait-for-jupyterhub
     image: {{ .Values.testImages.python.repository }}:{{ .Values.testImages.python.tag}}
-    command: [
-      "/bin/sleep",
-      "15"
-    ]
+    args:
+    - bash
+    - /scripts/wait_for_jupyterhub.sh
+    env:
+    - name: HUB_API_URL
+      value: http://proxy-public/hub/api
+    volumeMounts:
+    - name: scripts
+      mountPath: /scripts
+      readOnly: true
   containers:
   - name: test
     image: {{ .Values.testImages.python.repository }}:{{ .Values.testImages.python.tag}}

--- a/kubernetes/gaffer-jhub/templates/tests/notebook-tests/pod.yaml
+++ b/kubernetes/gaffer-jhub/templates/tests/notebook-tests/pod.yaml
@@ -9,6 +9,13 @@ metadata:
     helm.sh/hook: test-success
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
+  initContainers:
+  - name: wait-for-jupyterhub
+    image: {{ .Values.testImages.python.repository }}:{{ .Values.testImages.python.tag}}
+    command: [
+      "/bin/sleep",
+      "15"
+    ]
   containers:
   - name: test
     image: {{ .Values.testImages.python.repository }}:{{ .Values.testImages.python.tag}}

--- a/kubernetes/gaffer-jhub/values.yaml
+++ b/kubernetes/gaffer-jhub/values.yaml
@@ -129,10 +129,6 @@ optionsServer:
       spark.kubernetes.driver.label.app.kubernetes.io/component: notebook-spark-config
       spark.kubernetes.executor.label.app.kubernetes.io/name: gaffer-jhub
       spark.kubernetes.executor.label.app.kubernetes.io/component: notebook-spark-config
-      spark.driver.cores: 1
-      spark.driver.memory: 1g
-      spark.executor.cores: 1
-      spark.executor.memory: 1g
       spark.dynamicAllocation.enabled: true
       spark.dynamicAllocation.shuffleTracking.enabled: true
       spark.dynamicAllocation.executorIdleTimeout: 60s


### PR DESCRIPTION
This PR resolves the following issues in the options server:
- The spark.executor.cores value was being set to the value of executor memory in the Options Server UI.
- spark.executor.cores can only set to a positive integer however the UI allowed setting fractions of cores.