### PR TITLE
Enable Spark Ingress Path functionality

### DIFF
--- a/docker/gaffer-jhub-options-server/server.js
+++ b/docker/gaffer-jhub-options-server/server.js
@@ -277,6 +277,10 @@ const prespawn = async (username, server_name, pod_name, default_namespace, user
 				renderTemplate(profile.spark_ingress_host, {
 					USERNAME: username,
 					SERVERNAME: server_name || 'default'
+				}),
+				profile.spark_ingress_path == null ? null : renderTemplate(profile.spark_ingress_path, {
+					USERNAME: username,
+					SERVERNAME: server_name || 'default'
 				})
 			)
 			mergeObjects(config, podSpec)


### PR DESCRIPTION
This PR adds the final parameter to SparkConfigProvisioner::getPodSpecConfig to provision a path on the ingress for the Spark UI, conditionally checking the path template has been configured in the profile list.