### PR TITLE
Workaround to 'Datanode denied communication with namenode' error

### DIFF
--- a/kubernetes/hdfs/templates/config.yaml
+++ b/kubernetes/hdfs/templates/config.yaml
@@ -33,6 +33,10 @@ data:
         <value>{{$v}}</value>
       </property>
 {{- end }}
+      <property>
+        <name>dfs.namenode.datanode.registration.ip-hostname-check</name>
+        <value>false</value>
+      </property>
     </configuration>
 
   hdfs-site.xml: |-


### PR DESCRIPTION
While I was given the HDFS helm chart a try on my kind cluster I bumped into this problem:

```
2021-02-22 18:41:43,830 INFO datanode.DataNode: Block pool BP-171649713-10.244.0.11-1614008186939 (Datanode Uuid f072aa67-143b-489a-9a5f-c0ef3acf09c6) service to hdfs-namenode-0.hdfs-namenodes/10.244.0.27:8021 beginning handshake with NN
2021-02-22 18:41:43,833 ERROR datanode.DataNode: Initialization failed for Block pool BP-171649713-10.244.0.11-1614008186939 (Datanode Uuid f072aa67-143b-489a-9a5f-c0ef3acf09c6) service to hdfs-namenode-0.hdfs-namenodes/10.244.0.27:8021 Datanode denied communication with namenode because hostname cannot be resolved (ip=10.244.0.30, hostname=10.244.0.30): DatanodeRegistration(0.0.0.0:9866, datanodeUuid=f072aa67-143b-489a-9a5f-c0ef3acf09c6, infoPort=9864, infoSecurePort=0, ipcPort=9867, storageInfo=lv=-57;cid=CID-13c77a51-508c-4f34-b036-396c71ac439e;nsid=1679940402;c=1614008186939)
        at org.apache.hadoop.hdfs.server.blockmanagement.DatanodeManager.registerDatanode(DatanodeManager.java:1026)
        at org.apache.hadoop.hdfs.server.blockmanagement.BlockManager.registerDatanode(BlockManager.java:2452)
        at org.apache.hadoop.hdfs.server.namenode.FSNamesystem.registerDatanode(FSNamesystem.java:3913)
        at org.apache.hadoop.hdfs.server.namenode.NameNodeRpcServer.registerDatanode(NameNodeRpcServer.java:1538)
        at org.apache.hadoop.hdfs.protocolPB.DatanodeProtocolServerSideTranslatorPB.registerDatanode(DatanodeProtocolServerSideTranslatorPB.java:101)
        at org.apache.hadoop.hdfs.protocol.proto.DatanodeProtocolProtos$DatanodeProtocolService$2.callBlockingMethod(DatanodeProtocolProtos.java:31660)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:528)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1070)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:999)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:927)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1730)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2915)
```

The proposed change is a workaround I've found and I was able to confirm it worked out as expected.

I'm not an HDFS experienced user, just starting to learn about it so it may be another more suitable solution - I've just wanted to share this in case it helps others.