### PR TITLE
rename "ui" -> "gaffer-app"  ingress.yaml

### DIFF
--- a/kubernetes/gaffer/templates/ingress.yaml
+++ b/kubernetes/gaffer/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
   name: {{ include "gaffer.fullname" . }}-app
   labels:
     {{- include "gaffer.labels" . | nindent 4 }}
-    app.kubernetes.io/component: ui
+    app.kubernetes.io/component: gaffer-app
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
The app.kubernetes.io/component: ui annotation in /kubernetes/gaffer/template/ingress.yaml gives the impression that the ingress only serves the UI rather than the UI and REST API.

Changed to "gaffer-app"

# Related Issue

- Resolve #149