### PR TITLE
gh-98 Stop git from auto converting line endings on clone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+


### PR DESCRIPTION
Looks like, by default, git will automatically convert the line endings of files from LF to CRLF on Windows. When building the container images, Docker Desktop for Windows will copy these files inside a Linux VM. When our dockerfiles try to execute bash build scripts they will fail because they have the wrong line endings. This file will hopefully stop git from auto converting the line endings when it clones the repo. Info and fix lifted from [here](https://techblog.dorogin.com/case-of-windows-line-ending-in-bash-script-7236f056abe).

# Related Issue

- Resolve #98