### PR TITLE
Gh-284: Improve log output of publish_images.sh

### DIFF
--- a/cd/publish_images.sh
+++ b/cd/publish_images.sh
@@ -62,12 +62,14 @@ pushContainer() {
     # Upload to Docker Hub Container Image Library
     for tag in "${tagArray[@]}"; do
         docker tag "${name}:${version}" "${tag}"
-        docker push "${tag}"
+        echo "Uploading ${tag} to docker.io"
+        docker push --quiet "${tag}"
     done
     # Upload to GitHub Container Repository
     for tag in "${tagArray[@]}"; do
         docker tag "${name}:${version}" ghcr.io/"${tag}"
-        docker push ghcr.io/"${tag}"
+        echo "Uploading ${tag} to ghcr.io"
+        docker push --quiet ghcr.io/"${tag}"
     done
 }
 


### PR DESCRIPTION
This makes the push command quiet, only printing a single line - the tag if it is successful or the error and tag if not. Before the push the tag and repository are printed with `echo`.

# Related Issue

- Resolve #284