### PR TITLE
Gh-359: Add Tinkerpop serializer

### DIFF
--- a/docker/gaffer-gremlin/conf/gaffer-gremlin-server.yaml
+++ b/docker/gaffer-gremlin/conf/gaffer-gremlin-server.yaml
@@ -33,6 +33,7 @@ serializers:
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1 }
   # application/vnd.graphbinary-v1.0-stringd
   - { className: org.apache.tinkerpop.gremlin.util.ser.GraphBinaryMessageSerializerV1, config: { serializeResultToString: true }}
+  - { className: org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3, config: { ioRegistries: [org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3] }}
 
 metrics: {
   slf4jReporter: {enabled: true, interval: 180000}


### PR DESCRIPTION
Added v3 Tinkerpop serializer so modern tooling can talk to it rather than using the v1 fallback.

# Related issue

- Resolve #359