### PR TITLE
Updated Zookeeper Depencency

### DIFF
--- a/kubernetes/accumulo/Chart.yaml
+++ b/kubernetes/accumulo/Chart.yaml
@@ -22,8 +22,8 @@ sources:
   - https://github.com/gchq/gaffer-docker
 dependencies:
   - name: zookeeper
-    version: 2.1.5
-    repository: https://charts.helm.sh/incubator/
+    version: 11.4.11
+    repository: https://charts.bitnami.com/bitnami/
     condition: zookeeper.enabled
   - name: hdfs
     version: ^2.2.2 # managed version

--- a/kubernetes/accumulo/templates/_helpers.tpl
+++ b/kubernetes/accumulo/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- /*
 
-Copyright 2020-2022 Crown Copyright
+Copyright 2020-2024 Crown Copyright
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kubernetes/accumulo/templates/_helpers.tpl
+++ b/kubernetes/accumulo/templates/_helpers.tpl
@@ -1,3 +1,20 @@
+{{- /*
+
+Copyright 2020-2022 Crown Copyright
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/ -}}
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.

--- a/kubernetes/accumulo/templates/_helpers.tpl
+++ b/kubernetes/accumulo/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Create the name of the service account to use
 
 {{- define "accumulo.zookeepers" -}}
   {{- if .Values.zookeeper.enabled -}}
-    {{ template "accumulo.callSubChartTemplate" (list . "zookeeper" "zookeeper.fullname") }}
+    {{ template "accumulo.callSubChartTemplate" (list . "zookeeper" "zookeeper.image") }}
   {{- else -}}
     {{- required ".Values.zookeeper.enabled = false, so .Values.zookeeper.externalHosts must be set" .Values.zookeeper.externalHosts }}
   {{- end -}}


### PR DESCRIPTION
Updated Zookeeper dependency so that the Helm charts can be installed on a more up to date version of K8s

Relates to issue: https://github.com/gchq/gaffer-docker/issues/255