### PR TITLE
Gh-376: Improve release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Crown Copyright
+# Copyright 2020-2024 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-releasenotes:
-  sections:
-  - title: "Headliners"
-    emoji: ":star:"
-    labels: [ "headliner" ]
-  - title: "New Features"
-    emoji: ":gift:"
-    labels: [ "feature" ]
-  - title: "Enhancements"
-    emoji: ":sparkles:"
-    labels: [ "enhancement" ]
-  - title: "Bugs Fixed"
-    emoji: ":beetle:"
-    labels: [ "bug" ]
-  - title: "Documentation"
-    emoji: ":book:"
-    labels: "documentation"
-  - title: "Automation"
-    emoji: ":robot:"
-    labels: [ "automation" ]
+changelog:
+  categories:
+  - title: Headliners
+    labels:
+      - headliner
+  - title: New Features
+    labels:
+      - feature
+  - title: Enhancements
+    labels:
+      - enhancement
+  - title: Bugs Fixed
+    labels:
+      - bug
+  - title: Documentation
+    labels:
+      - documentation
+  - title: Automation
+    labels:
+      - automation

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -61,6 +61,6 @@ jobs:
 
     - name: Create PR to master
       run: |
-        gh pr create -B master -H $BRANCH_NAME --title 'Merge release into master branch' --body 'Created by GH Action'
+        gh pr create -B master -H $BRANCH_NAME --title 'Updated Gaffer version to ${{ github.event.milestone.title }}' --body 'Created by GH Action'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 Crown Copyright
+# Copyright 2021-2024 Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
 name: Create Release Branch
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release Branch Version'
-        required: false
+  milestone:
+    types:
+    - closed
 
 jobs:
   create-release-branch:
@@ -30,28 +28,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: develop
-        token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
 
-    - name: Set version from input
-      if: ${{ github.event.inputs.version }}
-      run: echo "RELEASE_VERSION=$(echo ${{ github.event.inputs.version }} | sed 's/^v//')" >> $GITHUB_ENV
-
-    - name: Get latest tag
-      if: ${{ !github.event.inputs.version }}
-      uses: actions-ecosystem/action-get-latest-tag@v1
-      id: get-latest-tag
-
-    - name: Format latest tag
-      if: ${{ !github.event.inputs.version }}
-      run: echo "CURRENT_VERSION=$(echo ${{ steps.get-latest-tag.outputs.tag }} | sed 's/^v//')" >> $GITHUB_ENV
-
-    - name: Bump latest tag variable version
-      if: ${{ !github.event.inputs.version }}
-      run: echo "RELEASE_VERSION=$(echo ${{ env.CURRENT_VERSION }} | sed -r 's/([0-9]+)\.([0-9]+)\.([0-9]+)/echo \1.$((\2+1)).0/' | sh)" >> $GITHUB_ENV
-
-    - name: Verify version regex
-      run: echo ${{ env.RELEASE_VERSION }} | grep -E '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+    - name: Set version from milestone
+      if: ${{ github.event.milestone.title }}
+      run: echo "RELEASE_VERSION=$(echo ${{ github.event.milestone.title }} | sed 's/^v//')" >> $GITHUB_ENV
 
     - name: Set release branch
       run: echo "BRANCH_NAME=$(echo release/${{ env.RELEASE_VERSION }} )" >> $GITHUB_ENV
@@ -62,10 +44,30 @@ jobs:
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
     - name: Update versions
-      run: ./cd/update_versions.sh ${RELEASE_VERSION}
+      run: |
+        ./cd/update_versions.sh ${RELEASE_VERSION}
+
+        find . -type f -exec sed -i "s/GAFFER_VERSION=[0-9]\.[0-9]\.[0-9]/GAFFER_VERSION=${{env.RELEASE_VERSION}}/g" {} +
+        find . -type f -exec sed -E -i "s/GAFFERPY_VERSION=(gafferpy-)?[0-9]\.[0-9]\.[0-9]/GAFFERPY_VERSION=\1${{env.RELEASE_VERSION}}/g" {} +
+        find . -type f -exec sed -i "s/GAFFER_TESTER_VERSION=[0-9]\.[0-9]\.[0-9]/GAFFER_TESTER_VERSION=${{env.RELEASE_VERSION}}/g" {} +
+        sed -i'' -e "s/<gaffer.version>[0-9]\.[0-9]\.[0-9]/<gaffer.version>${{env.RELEASE_VERSION}}/g" docker/gaffer-gremlin/pom.xml
+        sed -i'' -e "s/BASE_IMAGE_TAG=[0-9]\.[0-9]\.[0-9]/BASE_IMAGE_TAG=${{env.RELEASE_VERSION}}/g" docker/gaffer-kerberos/gaffer-krb/Dockerfile
+        sed -i'' -e "s/BASE_IMAGE_TAG=[0-9]\.[0-9]\.[0-9]/BASE_IMAGE_TAG=${{env.RELEASE_VERSION}}/g" docker/gaffer-kerberos/gaffer-rest-krb/Dockerfile
 
     - name: Push to release branch
       run: |
         git checkout -b $BRANCH_NAME
         git commit -a -m "prepare release v${RELEASE_VERSION}" --allow-empty
         git push --set-upstream origin $BRANCH_NAME
+
+    - name: Tag release branch
+      run: |
+        git tag v${RELEASE_VERSION}
+        git push origin v${RELEASE_VERSION}
+        git push
+
+    - name: Create PR to master
+      run: |
+        gh pr create -B master -H $BRANCH_NAME --title 'Merge release into master branch' --body 'Created by GH Action'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: develop
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         fetch-depth: 0
 
     - name: Set version from milestone
@@ -46,13 +46,6 @@ jobs:
     - name: Update versions
       run: |
         ./cd/update_versions.sh ${RELEASE_VERSION}
-
-        find . -type f -exec sed -i "s/GAFFER_VERSION=[0-9]\.[0-9]\.[0-9]/GAFFER_VERSION=${{env.RELEASE_VERSION}}/g" {} +
-        find . -type f -exec sed -E -i "s/GAFFERPY_VERSION=(gafferpy-)?[0-9]\.[0-9]\.[0-9]/GAFFERPY_VERSION=\1${{env.RELEASE_VERSION}}/g" {} +
-        find . -type f -exec sed -i "s/GAFFER_TESTER_VERSION=[0-9]\.[0-9]\.[0-9]/GAFFER_TESTER_VERSION=${{env.RELEASE_VERSION}}/g" {} +
-        sed -i'' -e "s/<gaffer.version>[0-9]\.[0-9]\.[0-9]/<gaffer.version>${{env.RELEASE_VERSION}}/g" docker/gaffer-gremlin/pom.xml
-        sed -i'' -e "s/BASE_IMAGE_TAG=[0-9]\.[0-9]\.[0-9]/BASE_IMAGE_TAG=${{env.RELEASE_VERSION}}/g" docker/gaffer-kerberos/gaffer-krb/Dockerfile
-        sed -i'' -e "s/BASE_IMAGE_TAG=[0-9]\.[0-9]\.[0-9]/BASE_IMAGE_TAG=${{env.RELEASE_VERSION}}/g" docker/gaffer-kerberos/gaffer-rest-krb/Dockerfile
 
     - name: Push to release branch
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Release
+name: Full Release
 
 on:
-  milestone:
-    types:
-    - closed
-  workflow_dispatch:
+  pull_request:
+    branches:
+        - master
+    types: [closed]
 
 jobs:
-  create-release-tag:
+  get-release-version:
     runs-on: ubuntu-latest
-    if: github.event_name == 'milestone'
+    if: ${{ github.event.pull_request.merged }}
     outputs:
-      branch_name: ${{ steps.branch.outputs.branch_name }}
+      release_version: ${{ steps.release-version.outputs.release_version }}
 
     steps:
     - name: Checkout master
@@ -34,48 +34,32 @@ jobs:
         ref: master
         token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         fetch-depth: 0
-    
+
     - name: Set up Github credentials
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-    
+
+    - name: Get latest tag
+      uses: actions-ecosystem/action-get-latest-tag@v1
+      id: get-latest-tag
+
+    - name: Format latest tag
+      run: echo "CURRENT_VERSION=$(echo ${{ steps.get-latest-tag.outputs.tag }} | sed 's/^v//')" >> $GITHUB_ENV
+
     - name: Set release version
-      run: echo "RELEASE_VERSION=$(echo ${{ github.event.milestone.title }} | cut -c 2-)" >> $GITHUB_ENV
-
-    - name: Set branch name
-      run: echo "BRANCH_NAME=$(git branch -a | grep $RELEASE_VERSION | tail -n 1 | cut -c 18-)" >> $GITHUB_ENV
-
-    - name: Output branch name
-      id: branch
-      run: echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-
-    - name: Fail if no branch found
-      if: ${{ !env.BRANCH_NAME }}
-      run: exit 1
-
-    - name: Merge release into master
-      run: |
-        git checkout ${{ env.BRANCH_NAME }}
-        git checkout master
-        git merge ${{ env.BRANCH_NAME }}
-
-    - name: Push changes
-      run: |
-        git tag v${RELEASE_VERSION}
-        git push origin v${RELEASE_VERSION}
-        git push
+      id: release-version
+      run: echo "release_version=$(echo $CURRENT_VERSION)" >> $GITHUB_OUTPUT
 
   update-branches:
     runs-on: ubuntu-latest
-    if: github.event_name == 'milestone'
     strategy:
       matrix:
         branch:
         - develop
         - gh-pages
     needs:
-    - create-release-tag
+    - get-release-version
 
     steps:
     - uses: actions/checkout@v4
@@ -83,17 +67,15 @@ jobs:
         ref: ${{ matrix.branch }}
         token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         fetch-depth: 0
-    
+
     - name: Set up Github credentials
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-  
-    - name: Merge release into branch
+
+    - name: Merge master into branches
       run: |
-        git checkout ${{ needs.create-release-tag.outputs.branch_name }}
-        git checkout ${{ matrix.branch }}
-        git merge ${{ needs.create-release-tag.outputs.branch_name }} --strategy-option theirs
+        git merge origin/master
         git push
 
   publish-images-to-dockerhub:
@@ -103,7 +85,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: develop
-        
+
     - name: Build images with Accumulo 2 dependency
       run: ./cd/build_images.sh ./docker/accumulo2.env
 
@@ -118,46 +100,31 @@ jobs:
         GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       run: ./cd/publish_images.sh
 
-  create-release-notes:
+  update-github-releases:
     runs-on: ubuntu-latest
-    if: github.event_name == 'milestone'
     needs:
-    - create-release-tag
-    - update-branches
-
-    outputs:
-      release_upload_url: ${{ steps.upload_notes.outputs.upload_url }}
+    - get-release-version
 
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: develop
-    
-    - name: Create Release Notes
-      id: create_release_notes
-      uses: docker://decathlon/release-notes-generator-action:3.1.6
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ref: master
 
     - name: Set version
-      run: echo "RELEASE_VERSION=$(echo ${{ github.event.milestone.title }} | cut -c 2-)" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=$(echo ${{ needs.get-release-version.outputs.release_version }})" >> $GITHUB_ENV
 
-    - name: Upload notes
-      id: upload_notes
+    - name: Create github release
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: v${{ env.RELEASE_VERSION }}
         name: Gaffer Docker ${{ env.RELEASE_VERSION }}
-        body_path: release_file.md
 
   upload-release-artifacts:
     runs-on: ubuntu-latest
-    if: github.event_name == 'milestone'
     needs:
-    - create-release-tag
-    - create-release-notes
+    - get-release-version
     strategy:
       matrix:
         chart:
@@ -171,10 +138,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: develop
-    
+
     - name: Install dependencies
       run: ./cd/install_dependencies.sh
-    
+
     - name: Create Asset
       env:
         chart: ${{ matrix.chart }}
@@ -182,22 +149,21 @@ jobs:
         helm package "kubernetes/${chart}"
         filename=$(ls | grep ${chart}-[0-9]*.[0-9]*.[0-9]*.tgz)
         echo "ASSET_FILENAME=${filename}" >> $GITHUB_ENV
-    
+
     - name: Upload chart artifact
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.chart }}
         path: ${{ env.ASSET_FILENAME }}
         retention-days: 1
-    
+
     - name: Upload Asset
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload ${{ github.event.milestone.title }} ${{ env.ASSET_FILENAME }}
+      run: gh release upload ${{ steps.release-version.outputs.release_version }} ${{ env.ASSET_FILENAME }}
 
   update-helm-repo:
     runs-on: ubuntu-latest
-    if: github.event_name == 'milestone'
     needs:
     - upload-release-artifacts
 
@@ -207,7 +173,7 @@ jobs:
       with:
         ref: gh-pages
         token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-    
+
     - name: Set up Github credentials
       run: |
         git config user.name github-actions[bot]
@@ -221,7 +187,7 @@ jobs:
     - name: Update repo
       run: |
         mv artifacts/*/*.tgz .
-        helm repo index . --url "https://github.com/gchq/gaffer-docker/releases/download/${{ github.event.milestone.title }}" --merge index.yaml
+        helm repo index . --url "https://github.com/gchq/gaffer-docker/releases/download/${{ steps.release-version.outputs.release_version }}" --merge index.yaml
         sed -i'' -e 's|file://.*|https://gchq.github.io/gaffer-docker|g' index.yaml
         rm *.tgz
         rm -r artifacts

--- a/cd/update_versions.sh
+++ b/cd/update_versions.sh
@@ -27,6 +27,14 @@ source ./docker/accumulo2.env
 # JHUB_OPTIONS_SERVER_VERSION
 source ./docker/gaffer-jhub-options-server/get-version.sh
 
+# Update docker versions
+find . -type f -exec sed -i "s/GAFFER_VERSION=[0-9]\.[0-9]\.[0-9]/GAFFER_VERSION=${APP_VERSION}/g" {} +
+find . -type f -exec sed -E -i "s/GAFFERPY_VERSION=(gafferpy-)?[0-9]\.[0-9]\.[0-9]/GAFFERPY_VERSION=\1${APP_VERSION}/g" {} +
+find . -type f -exec sed -i "s/GAFFER_TESTER_VERSION=[0-9]\.[0-9]\.[0-9]/GAFFER_TESTER_VERSION=${APP_VERSION}/g" {} +
+sed -i'' -e "s/<gaffer.version>[0-9]\.[0-9]\.[0-9]/<gaffer.version>${APP_VERSION}/g" docker/gaffer-gremlin/pom.xml
+sed -i'' -e "s/BASE_IMAGE_TAG=[0-9]\.[0-9]\.[0-9]/BASE_IMAGE_TAG=${APP_VERSION}/g" docker/gaffer-kerberos/gaffer-krb/Dockerfile
+sed -i'' -e "s/BASE_IMAGE_TAG=[0-9]\.[0-9]\.[0-9]/BASE_IMAGE_TAG=${APP_VERSION}/g" docker/gaffer-kerberos/gaffer-rest-krb/Dockerfile
+
 # hdfs
 [ ! -z "${APP_VERSION}" ] && yq eval ".version = \"${APP_VERSION}\"" -i ./kubernetes/hdfs/Chart.yaml
 yq eval ".appVersion = \"${HADOOP_VERSION}\"" -i ./kubernetes/hdfs/Chart.yaml


### PR DESCRIPTION
In line with the release of the main Gaffer repo, the workflows should now create a release branch when the current milestone is closed and use this for the release version. This will run a script updating all the env, Dockerfiles and yaml files and create a branch with these changes and any other changes during this release. The branch will then need approving and merging. This will then trigger the release action when the branch is merged to main. 

# Related issue

- Resolve #376